### PR TITLE
Remove `\u1` character that crashed CI

### DIFF
--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -329,7 +329,7 @@ defmodule Phoenix.View do
 
   @doc """
   See `render_one/4`.
-  """
+  """
   def render_one(model, template) when is_binary(template) do
     render_one(model, template, %{})
   end


### PR DESCRIPTION
Hi there! Very new newcomer to the Elixir / Phoenix community. I noticed the last few CI builds were failing and "spotted" a `\u1` that shouldn't be there.

After hearing such wonderful things about this community, I had to pounce on this small opportunity to contribute!

Thanks again for your hard work!